### PR TITLE
Reorder paths: path reversal is now possible

### DIFF
--- a/inkscape_driver/eggbot_reorder.inx
+++ b/inkscape_driver/eggbot_reorder.inx
@@ -6,27 +6,27 @@
   <dependency type="executable" location="extensions">eggbot_reorder.py</dependency>
   <dependency type="executable" location="extensions">inkex.py</dependency>
   <!-- Written by Matthew Beckler for the Egg-Bot project. Email questions and comments to matthew at mbeckler dot org -->
-
-	  <_param name="Header" type="description" xml:space="preserve">
- This extension will perform simple optimizations 
- of selected paths. It will try to change the 
+  <_param name="Header" type="description" xml:space="preserve">
+ This extension will perform simple optimizations
+ of selected paths. It will try to change the
  order of plotting so as to reduce the amount
  of "pen-up" travel that occurs between paths.
- 
+
  Solving for optimal plot order is a difficult
  problem, known in computer science as the
- "traveling salesman problem," or just "TSP."  
- 
+ "traveling salesman problem," or just "TSP".
+
  This routine does not look for the best possible
  solution; that can be slow. Instead it tries a
- few quick methods that often reduce pen-up 
- travel distance (and time) by 30% or more. 
+ few quick methods that often reduce pen-up
+ travel distance (and time) by 30% or more.
 
- Please note: This extension is still considered 
- experimental, and is only provided in case you 
- may find it useful. Be sure to save a copy of 
+ Please note: This extension is still considered
+ experimental, and is only provided in case you
+ may find it useful. Be sure to save a copy of
  your document before running this routine.
-            </_param>
+  </_param>
+  <param name="allowReverse" type="boolean" _gui-text="Allow Reverse">true</param>
 
   <!--
   <param name="reverse" type="boolean" _gui-text="Allow paths to be reversed*">false</param>


### PR DESCRIPTION
Improves the greedy algorithm by allowing paths to be reversed (some path commands like A are not supported).
Also, it now handles groups by considering them as a single path so it will not modify the order inside of the group. At the moment, it cannot reverse a group.

![pathreversalcomparison](https://user-images.githubusercontent.com/16589387/33238360-692c40c8-d28c-11e7-8178-56f71d4e8ae6.jpg)
