### PR TITLE
Fixed missing quotation and tag mismatch.

### DIFF
--- a/inkscape_driver/eggbot_conf.py
+++ b/inkscape_driver/eggbot_conf.py
@@ -14,7 +14,7 @@ N_PAGE_HEIGHT = 800  # Default Inkscape page height (each unit equiv. to one pix
 N_PAGE_WIDTH = 3200  # Default Inkscape page width (each unit equiv. to one pixel/step)
 
 """
-Motor resolution: The "standard" setup for brand-name EggBot machines (at least through 2015) has been 3200 steps per revolution. 
+Motor resolution: The "standard" setup for brand-name EggBot machines (at least through 2015) has been 3200 steps per revolution.
 
 Early (clear-chassis) models had 400 step/rev motors with 8X microstepping drivers, and more recent versions ("white-chassis" EggBot 2.0, Deluxe EggBot, Ostrich EggBot, and EggBot Pro) have all used 200 step/rev motors with 16X microstepping drivers (EBB 2.0).
 
@@ -29,7 +29,7 @@ For NORMAL USE, with overall 3200 steps/rev, use the default value:
 
 For 6400 steps/rev, use:
     STEP_SCALE = 1
-    
+
 Other _integer_ scaling values can be used as well, with similar scaling.
 
 """

--- a/inkscape_driver/eggbot_hatch.inx
+++ b/inkscape_driver/eggbot_hatch.inx
@@ -19,11 +19,11 @@
 This extension fills each closed figure in your drawing
 with a path consisting of back and forth drawn "hatch" lines.
 If any objects are selected, then only those selected objects
-will be filled. 
+will be filled.
 
 Hatched figures will be grouped with their fills.
   </_param>
-  <param name="hatchSpacing" type="float" min=0.1" max="1000" _gui-text="   Hatch spacing (px)">5.0</param>
+  <param name="hatchSpacing" type="float" min="0.1" max="1000" _gui-text="   Hatch spacing (px)">5.0</param>
   <param name="hatchAngle" type="float" min="-360" max="360" _gui-text="   Hatch angle (degrees)">45</param>
   <param name="crossHatch" type="boolean" _gui-text="   Crosshatch?">false</param>
 
@@ -32,13 +32,13 @@ Hatched figures will be grouped with their fills.
   <param name="holdBackHatchFromEdges" type="boolean" _gui-text="   Inset fill from edges?">true</param>
   <param name="holdBackSteps" type="float" min="0.1" max="10.0" _gui-text="   Inset distance (px) (default: 1)">1.0</param>
   <param name="tolerance" type="float" min="0.1" max="100" _gui-text="   Tolerance (default: 20)">20.0</param>
-  <param name="footer" type="description" xml:space="preserve">
+  <_param name="footer" type="description" xml:space="preserve">
             (v2.1.0, December 8, 2017)</_param>
 
   </page>
   <page name="info" _gui-text="More info...">
   <_param name="aboutpage" type="description" xml:space="preserve">
-Hatch spacing is the distance between hatch lines, 
+Hatch spacing is the distance between hatch lines,
 measured in units of screen pixels (px). Angles are in
 degrees from horizontal; for example 90 is vertical.
 
@@ -50,9 +50,9 @@ nearby line ends with a smoothly flowing curve, to improve
 the smoothness of plotting.
 
 The Range parameter sets the distance (in hatch widths)
-over which that option searches for segments to join. 
+over which that option searches for segments to join.
 Large values may result in hatches where you don't want
-them. Consider using a value in the range of 2-4. 
+them. Consider using a value in the range of 2-4.
 
 The Inset option allows you to hold back the edges of the
 fill somewhat from the edge of your original object.
@@ -64,7 +64,7 @@ as the original object.
 
 The Tolerance parameter affects how precisely
 the hatches try to fill the input paths.</_param>
- 
+
   </page>
   </param>
   <effect needs-live-preview="true">

--- a/inkscape_driver/eggbot_hatch.py
+++ b/inkscape_driver/eggbot_hatch.py
@@ -71,7 +71,7 @@
 # Add min span/gap width
 
 # Updated by Windell H. Oskay, 1/8/2016
-# Added live preview and correct issue with nonzero min gap 
+# Added live preview and correct issue with nonzero min gap
 # https://github.com/evil-mad/EggBot/issues/32
 
 # Updated by Sheldon B. Michaels, 1/11/2016 thru 3/15/2016
@@ -84,12 +84,12 @@
 # Updated by Nathan Depew, 12/6/2017
 # Modified hatch fill to create hatches as a relevant object it found on the SVG tree
 # This prevents extremely complex plots from generating glitches
-# Modifications are limited to recursivelyTraverseSvg and effect methods 
+# Modifications are limited to recursivelyTraverseSvg and effect methods
 
 #
 # Current software version:
 # (v2.1.0, December 6, 2017)
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation; either version 2 of the License, or
@@ -118,7 +118,7 @@ from simpletransform import applyTransformToPath, applyTransformToPoint, compose
 N_PAGE_WIDTH = 3200
 N_PAGE_HEIGHT = 800
 
-F_MINGAP_SMALL_VALUE = 0.0000000001  
+F_MINGAP_SMALL_VALUE = 0.0000000001
 # Was 0.00001 in the original version which did not have joined lines.
 # Reducing this by a factor of 10^5 decreased probability of occurrence of
 # the bug in the original, which got confused when the path barely
@@ -129,21 +129,21 @@ BEZIER_OVERSHOOT_MULTIPLIER = 0.75  # evaluation of cubic Bezier curve equation 
 # endpoints at ( -0.5, 0 ), ( +0.5, 0 )
 # and control points at ( -0.5, 1.0 ), ( +0.5, 1.0 )
 
-RADIAN_TOLERANCE_FOR_COLINEAR = 0.1  
+RADIAN_TOLERANCE_FOR_COLINEAR = 0.1
 # Pragmatically adjusted to allow adjacent segments from the same scan line, even short ones,
 # to be classified as having the same angle
 
-RADIAN_TOLERANCE_FOR_ALTERNATING_DIRECTION = 0.1  
+RADIAN_TOLERANCE_FOR_ALTERNATING_DIRECTION = 0.1
 # Pragmatic adjustment again, as with colinearity tolerance
 
-RECURSION_LIMIT = 500  
-# Pragmatic - if too high, risk runtime python error; 
+RECURSION_LIMIT = 500
+# Pragmatic - if too high, risk runtime python error;
 # if too low, miss some chances for reducing pen lifts
 
 EXTREME_POS = 1.0E70 # Extremely large positive number
 EXTREME_NEG = -1.0E70 # Extremely large negative number
 
-MIN_HATCH_FRACTION = 0.25  
+MIN_HATCH_FRACTION = 0.25
 # Minimum hatch length, as a fraction of the hatch spacing.
 
 """
@@ -790,7 +790,7 @@ class Eggbot_Hatch(inkex.Effect):
 
             """
              Initialize dictionary for each new node
-             This allows us to create hatch fills as if each 
+             This allows us to create hatch fills as if each
              object to be hatched has been selected individually
 
             """
@@ -1337,9 +1337,9 @@ class Eggbot_Hatch(inkex.Effect):
                     direction = not direction
 
                 # Now have a nice juicy buffer full of line segments with absolute coordinates
-                f_proposed_neighborhood_radius_squared = self.ProposeNeighborhoodRadiusSquared(transformed_hatch_spacing)  
+                f_proposed_neighborhood_radius_squared = self.ProposeNeighborhoodRadiusSquared(transformed_hatch_spacing)
                 # Just fixed and simple for now - may make function of neighborhood later
-                
+
                 for ref_count in range(n_abs_line_segment_total):  # This is the entire range of segments,
                     # Sets global ref_count to segment which has an end closest to current pen position.
                     # Doesn't need to select which end is closest, as that will happen below, with n_ref_end_index.


### PR DESCRIPTION
Fixed tag mismatch:
	Opening and ending tag mismatch: param line 35 and _param
            (v2.1.0, December 8, 2017)</_param>

Fixed missing quotation mark.