### PR TITLE
Fix for plotting individual layers when using python3/Inkscape-1.0beta1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 
 **/.DS_Store
 **/*.pyc
+
+# vim:
+*.swp

--- a/inkscape_driver/eggbot.py
+++ b/inkscape_driver/eggbot.py
@@ -24,6 +24,7 @@
 import gettext
 import math
 import time
+import sys
 
 from lxml import etree
 
@@ -906,8 +907,11 @@ class EggBot(inkex.Effect):
 
         temp_num_string = 'x'
         string_pos = 1
-        current_layer_name = str_layer_name.lstrip()  # remove leading whitespace
-
+        if sys.version_info < (3,):  # Yes this is ugly. More elegant suggestions welcome. :)
+            current_layer_name = str_layer_name.encode('ascii', 'ignore')  # Drop non-ascii characters
+        else:
+            current_layer_name = str(str_layer_name)
+        
         # Look at layer name.  Sample first character, then first two, and
         # so on, until the string ends or the string no longer consists of
         # digit characters only.

--- a/inkscape_driver/eggbot.py
+++ b/inkscape_driver/eggbot.py
@@ -906,7 +906,7 @@ class EggBot(inkex.Effect):
 
         temp_num_string = 'x'
         string_pos = 1
-        current_layer_name = str_layer_name.encode('ascii', 'ignore').lstrip()  # remove leading whitespace
+        current_layer_name = str_layer_name.lstrip()  # remove leading whitespace
 
         # Look at layer name.  Sample first character, then first two, and
         # so on, until the string ends or the string no longer consists of
@@ -915,14 +915,14 @@ class EggBot(inkex.Effect):
         max_length = len(current_layer_name)
         if max_length > 0:
             while string_pos <= max_length:
-                if str.isdigit(current_layer_name[:string_pos]):
+                if current_layer_name[:string_pos].isdigit():
                     temp_num_string = current_layer_name[:string_pos]  # Store longest numeric string so far
                     string_pos += 1
                 else:
                     break
 
         self.plotCurrentLayer = False  # Temporarily assume that we aren't plotting the layer
-        if str.isdigit(temp_num_string):
+        if temp_num_string.isdigit():
             if self.svgLayer == int(float(temp_num_string)):
                 self.plotCurrentLayer = True  # We get to plot the layer!
                 self.LayersPlotted += 1


### PR DESCRIPTION
This is a fix for #127. It fixes a py2/py3 compatibility issue observed when using the first beta of Inkscape-1.0, which bundles Python3, at least on MacOS.

The code change *should* work with python2, too, so you may consider cherry-picking 0691bbe8dc9f135703b2006c358284974674093a to master. However, I only verified in-vivo using Inkscake-1.0beta1 with Python3. Python2 testing was limited to some experiments in the REPL.