### PR TITLE
python3 compatibility: drop use of basestring

### DIFF
--- a/inkscape_driver/eggbot_hatch.py
+++ b/inkscape_driver/eggbot_hatch.py
@@ -1065,7 +1065,7 @@ class Eggbot_Hatch(inkex.Effect):
             elif node.tag in [inkex.addNS('text', 'svg'), 'text']:
                 inkex.errormsg('Warning: unable to draw text, please convert it to a path first.')
                 pass
-            elif not isinstance(node.tag, basestring):
+            elif not isinstance(node.tag, str):
                 pass
             else:
                 inkex.errormsg('Warning: unable to hatch object <{0}>, please convert it to a path first.'.format(node.tag))


### PR DESCRIPTION
That is all it take to make it run with python3.6 !

Not sure if saying str instead of basestring would make python2 unhappy with unicode, though...

Seen while reviewing https://github.com/fablabnbg/inkscape-silhouette/pull/94