### PR TITLE
add option for logging plotting commands to file

### DIFF
--- a/inkscape_driver/eggbot.inx
+++ b/inkscape_driver/eggbot.inx
@@ -20,6 +20,8 @@ Need help?
 Visit http://wiki.evilmadscientist.com/eggbot
 
 </label>
+<param indent="1" name="commandLog" type="path"
+gui-text="Log commands to the following file:"></param>
 </page>
 
 <page name='setup' gui-text='Setup'>

--- a/inkscape_driver/eggbot.py
+++ b/inkscape_driver/eggbot.py
@@ -137,6 +137,10 @@ class EggBot(inkex.Effect):
                                      action="store", type="inkbool",
                                      dest="revEggMotor", default=False,
                                      help="Reverse motion of egg motor.")
+        self.OptionParser.add_option("--commandLog",
+                                     action="store", type="string",
+                                     dest="commandLog", default="",
+                                     help="Log file for drawing commands.")
 
         self.allLayers = None
         self.plotCurrentLayer = None
@@ -202,6 +206,8 @@ class EggBot(inkex.Effect):
             self.serialPort = ebb_serial.openPort()
             if self.serialPort is None:
                 inkex.errormsg(gettext.gettext("Failed to connect to EggBot. :("))
+            if len(self.options.commandLog) > 0:
+                ebb_serial.startLogging(self.options.commandLog)
 
             if self.options.tab == "splash":
                 self.allLayers = True
@@ -251,6 +257,9 @@ class EggBot(inkex.Effect):
             if self.serialPort is not None:
                 ebb_motion.doTimedPause(self.serialPort, 10)  # Pause a moment for underway commands to finish...
                 ebb_serial.closePort(self.serialPort)
+
+            if len(self.options.commandLog) > 0:
+                ebb_serial.stopLogging()
 
         self.svgDataRead = False
         self.UpdateSVGEggbotData(self.svg)


### PR DESCRIPTION
This commit adds a UI option to the EggBot Inkscape extension to optionally log all commands sent to the EBB into a file.
It depends on additions to plotink (https://github.com/evil-mad/plotink/pull/53).
As the field for the filename is empty by default, logging is disabled by default.

A script ebb_replay_log.py (in the plotink repo) allows for replaying the list of commands to a serial port.

Together with changes to the plotink code, this makes it possible to create a design in Inkscape, save the plotting commands into a command log, and then plot the design again without requiring Inkscape.
This is useful for automated / repeated plotting of the same design.
