### PR TITLE
regularize imports in eggbot_hatch

### DIFF
--- a/inkscape_driver/eggbot_hatch.py
+++ b/inkscape_driver/eggbot_hatch.py
@@ -110,7 +110,7 @@
 import math
 from lxml import etree
 
-from axidrawinternal.plot_utils_import import from_dependency_import # plotink
+from plot_utils_import import from_dependency_import # plotink
 inkex = from_dependency_import('ink_extensions.inkex')
 simplepath = from_dependency_import('ink_extensions.simplepath')
 simpletransform = from_dependency_import('ink_extensions.simpletransform')


### PR DESCRIPTION
regularize imports in eggbot_hatch for 2 reasons. 1, to match other python files in this directory and 2, so that a wrapper is not necessary in the final installer build

Part of issue 20 in axidrawforinkscape.