### PR TITLE
migrate from optparse to argparse

### DIFF
--- a/inkscape_contributed/eggbot_maze.py
+++ b/inkscape_contributed/eggbot_maze.py
@@ -127,12 +127,12 @@ class Maze(inkex.Effect):
 
         inkex.Effect.__init__(self)
 
-        self.OptionParser.add_option(
-                "--tab", action="store", type="string",
+        self.arg_parser.add_argument(
+                "--tab", action="store", type=str,
                 dest="tab", default="controls",
                 help="The active tab when Apply was pressed")
-        self.OptionParser.add_option(
-                "--mazeSize", action="store", type="string", dest="mazeSize",
+        self.arg_parser.add_argument(
+                "--mazeSize", action="store", type=str, dest="mazeSize",
                 default="MEDIUM", help="Difficulty of maze to build")
 
         self.hpp = False

--- a/inkscape_contributed/eggbot_pptb.py
+++ b/inkscape_contributed/eggbot_pptb.py
@@ -36,17 +36,17 @@ class EggBot_PostProcessTraceBitmap(inkex.Effect):
 
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--outlineRegions", action="store", dest="outlineRegions",
-                type="inkbool", default=True,
+                type=inkex.boolean_option, default=True,
                 help="Outline the regions with a stroked line of the same color as the region itself")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--fillRegions", action="store", dest="fillRegions",
-                type="inkbool", default=True,
+                type=inkex.boolean_option, default=True,
                 help="Fill regions with color")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--removeImage", action="store", dest="removeImage",
-                type="inkbool", default=True,
+                type=inkex.boolean_option, default=True,
                 help="Remove the traced bitmap image from the drawing")
 
     def effect(self):

--- a/inkscape_contributed/eggbot_sineandlace.py
+++ b/inkscape_contributed/eggbot_sineandlace.py
@@ -258,53 +258,53 @@ class SpiroSine(inkex.Effect):
 
         inkex.Effect.__init__(self)
 
-        self.OptionParser.add_option("--tab",  # NOTE: value is not used.
-                                     action="store", type="string",
+        self.arg_parser.add_argument("--tab",  # NOTE: value is not used.
+                                     action="store", type=str,
                                      dest="tab", default="splash",
                                      help="The active tab when Apply was pressed")
 
-        self.OptionParser.add_option('--fCycles', dest='fCycles',
-                                     type='float', default=10.0, action='store',
+        self.arg_parser.add_argument('--fCycles', dest='fCycles',
+                                     type=float, default=10.0, action='store',
                                      help='Number of cycles (periods)')
 
-        self.OptionParser.add_option('--nrN', dest='nrN',
-                                     type='int', default=0, action='store',
+        self.arg_parser.add_argument('--nrN', dest='nrN',
+                                     type=int, default=0, action='store',
                                      help='Start x at 2 * pi * n / m')
 
-        self.OptionParser.add_option('--nrM', dest='nrM',
-                                     type='int', default=0, action='store',
+        self.arg_parser.add_argument('--nrM', dest='nrM',
+                                     type=int, default=0, action='store',
                                      help='Start x at 2 * pi * n / m')
 
-        self.OptionParser.add_option('--fRecess', dest='fRecess',
-                                     type='float', default=2.0, action='store',
+        self.arg_parser.add_argument('--fRecess', dest='fRecess',
+                                     type=float, default=2.0, action='store',
                                      help='Recede from envelope by factor')
 
-        self.OptionParser.add_option("--nSamples", dest="nSamples",
-                                     type="int", default=50.0, action="store",
+        self.arg_parser.add_argument("--nSamples", dest="nSamples",
+                                     type=int, default=50.0, action="store",
                                      help="Number of points to sample")
 
-        self.OptionParser.add_option("--nWidth", dest="nWidth",
-                                     type="int", default=3200, action="store",
+        self.arg_parser.add_argument("--nWidth", dest="nWidth",
+                                     type=int, default=3200, action="store",
                                      help="Width in pixels")
 
-        self.OptionParser.add_option("--nHeight", dest="nHeight",
-                                     type="int", default=100, action="store",
+        self.arg_parser.add_argument("--nHeight", dest="nHeight",
+                                     type=int, default=100, action="store",
                                      help="Height in pixels")
 
-        self.OptionParser.add_option("--nOffsetX", dest="nOffsetX",
-                                     type="int", default=0, action="store",
+        self.arg_parser.add_argument("--nOffsetX", dest="nOffsetX",
+                                     type=int, default=0, action="store",
                                      help="Starting x coordinate (pixels)")
 
-        self.OptionParser.add_option("--nOffsetY", dest="nOffsetY",
-                                     type="int", default=400, action="store",
+        self.arg_parser.add_argument("--nOffsetY", dest="nOffsetY",
+                                     type=int, default=400, action="store",
                                      help="Starting y coordinate (pixels)")
 
-        self.OptionParser.add_option('--bLace', dest='bLace',
-                                     type='inkbool', default=False, action='store',
+        self.arg_parser.add_argument('--bLace', dest='bLace',
+                                     type=inkex.boolean_option, default=False, action='store',
                                      help='Lace')
 
-        self.OptionParser.add_option('--bSpline', dest='bSpline',
-                                     type='inkbool', default=True, action='store',
+        self.arg_parser.add_argument('--bSpline', dest='bSpline',
+                                     type=inkex.boolean_option, default=True, action='store',
                                      help='Spline')
 
         self.recess = 0.95

--- a/inkscape_contributed/eggbot_twist.py
+++ b/inkscape_contributed/eggbot_twist.py
@@ -97,12 +97,12 @@ class Twist(inkex.Effect):
     def __init__(self):
 
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option(
-                "--nSteps", action="store", type="int",
+        self.arg_parser.add_argument(
+                "--nSteps", action="store", type=int,
                 dest="nSteps", default=8,
                 help="Number of iterations to take")
-        self.OptionParser.add_option(
-                "--fRatio", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--fRatio", action="store", type=float,
                 dest="fRatio", default=0.2,
                 help="Some ratio")
 

--- a/inkscape_driver/eggbot.py
+++ b/inkscape_driver/eggbot.py
@@ -57,84 +57,84 @@ class EggBot(inkex.Effect):
     def __init__(self):
         inkex.Effect.__init__(self)
 
-        self.OptionParser.add_option("--smoothness",
-                                     action="store", type="float",
+        self.arg_parser.add_argument("--smoothness",
+                                     action="store", type=float,
                                      dest="smoothness", default=.2,
                                      help="Smoothness of curves")
-        self.OptionParser.add_option("--returnToHome",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--returnToHome",
+                                     action="store", type=inkex.boolean_option,
                                      dest="returnToHome", default=True,
                                      help="Return to home at end of plot.")
-        self.OptionParser.add_option("--wraparound",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--wraparound",
+                                     action="store", type=inkex.boolean_option,
                                      dest="wraparound", default=True,
                                      help="Egg (x) axis wraps around-- take shortcuts!")
-        self.OptionParser.add_option("--penUpSpeed",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penUpSpeed",
+                                     action="store", type=int,
                                      dest="penUpSpeed", default=F_DEFAULT_SPEED,
                                      help="Speed (step/sec) while pen is up.")
-        self.OptionParser.add_option("--penDownSpeed",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penDownSpeed",
+                                     action="store", type=int,
                                      dest="penDownSpeed", default=F_DEFAULT_SPEED,
                                      help="Speed (step/sec) while pen is down.")
-        self.OptionParser.add_option("--penDownDelay",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penDownDelay",
+                                     action="store", type=int,
                                      dest="penDownDelay", default=N_PEN_DOWN_DELAY,
                                      help="Delay after pen down (msec).")
-        self.OptionParser.add_option("--penUpDelay",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penUpDelay",
+                                     action="store", type=int,
                                      dest="penUpDelay", default=N_PEN_UP_DELAY,
                                      help="Delay after pen up (msec).")
-        self.OptionParser.add_option("--engraving",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--engraving",
+                                     action="store", type=inkex.boolean_option,
                                      dest="engraving", default=False,
                                      help="Enable optional engraving tool.")
-        self.OptionParser.add_option("--tab",
-                                     action="store", type="string",
+        self.arg_parser.add_argument("--tab",
+                                     action="store", type=str,
                                      dest="tab", default="controls",
                                      help="The active tab when Apply was pressed")
-        self.OptionParser.add_option("--penUpPosition",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penUpPosition",
+                                     action="store", type=int,
                                      dest="penUpPosition", default=N_PEN_UP_POS,
                                      help="Position of pen when lifted")
-        self.OptionParser.add_option("--ServoDownSpeed",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--ServoDownSpeed",
+                                     action="store", type=int,
                                      dest="ServoDownSpeed", default=N_SERVOSPEED,
                                      help="Rate of lowering pen ")
-        self.OptionParser.add_option("--ServoUpSpeed",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--ServoUpSpeed",
+                                     action="store", type=int,
                                      dest="ServoUpSpeed", default=N_SERVOSPEED,
                                      help="Rate of lifting pen ")
-        self.OptionParser.add_option("--penDownPosition",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--penDownPosition",
+                                     action="store", type=int,
                                      dest="penDownPosition", default=N_PEN_DOWN_POS,
                                      help="Position of pen when lowered")
-        self.OptionParser.add_option("--layernumber",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--layernumber",
+                                     action="store", type=int,
                                      dest="layernumber", default=N_DEFAULT_LAYER,
                                      help="Selected layer for multilayer plotting")
-        self.OptionParser.add_option("--setupType",
-                                     action="store", type="string",
+        self.arg_parser.add_argument("--setupType",
+                                     action="store", type=str,
                                      dest="setupType", default="controls",
                                      help="The active option when Apply was pressed")
-        self.OptionParser.add_option("--manualType",
-                                     action="store", type="string",
+        self.arg_parser.add_argument("--manualType",
+                                     action="store", type=str,
                                      dest="manualType", default="controls",
                                      help="The active option when Apply was pressed")
-        self.OptionParser.add_option("--WalkDistance",
-                                     action="store", type="int",
+        self.arg_parser.add_argument("--WalkDistance",
+                                     action="store", type=int,
                                      dest="WalkDistance", default=N_WALK_DEFAULT,
                                      help="Selected layer for multilayer plotting")
-        self.OptionParser.add_option("--cancelOnly",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--cancelOnly",
+                                     action="store", type=inkex.boolean_option,
                                      dest="cancelOnly", default=False,
                                      help="Cancel plot and return home only.")
-        self.OptionParser.add_option("--revPenMotor",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--revPenMotor",
+                                     action="store", type=inkex.boolean_option,
                                      dest="revPenMotor", default=False,
                                      help="Reverse motion of pen motor.")
-        self.OptionParser.add_option("--revEggMotor",
-                                     action="store", type="inkbool",
+        self.arg_parser.add_argument("--revEggMotor",
+                                     action="store", type=inkex.boolean_option,
                                      dest="revEggMotor", default=False,
                                      help="Reverse motion of egg motor.")
 

--- a/inkscape_driver/eggbot_hatch.py
+++ b/inkscape_driver/eggbot_hatch.py
@@ -615,46 +615,46 @@ class Eggbot_Hatch(inkex.Effect):
         self.docHeight = float(N_PAGE_HEIGHT)
         self.docTransform = [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]
 
-        self.OptionParser.add_option(
-                "--inset_dist", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--inset_dist", action="store", type=float,
                 dest="inset_dist", default=3.0,
                 help="How far hatch strokes stay from boundary")
-        self.OptionParser.add_option(
-                "--hatchScope", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--hatchScope", action="store", type=float,
                 dest="hatchScope", default=3.0,
                 help="Radius searched for segments to join (units of hatch width)")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--inset_bool", action="store", dest="inset_bool",
-                type="inkbool", default=True,
+                type=inkex.boolean_option, default=True,
                 help="Stay away from edges, so no need for inset")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--connect_bool", action="store", dest="connect_bool",
-                type="inkbool", default=True,
+                type=inkex.boolean_option, default=True,
                 help="Reduce plotting time by joining some hatches")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--crossHatch", action="store", dest="crossHatch",
-                type="inkbool", default=False,
+                type=inkex.boolean_option, default=False,
                 help="Generate a cross hatch pattern")
-        self.OptionParser.add_option(
-                "--hatchAngle", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--hatchAngle", action="store", type=float,
                 dest="hatchAngle", default=90.0,
                 help="Angle of inclination for hatch lines")
-        self.OptionParser.add_option(
-                "--hatchSpacing", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--hatchSpacing", action="store", type=float,
                 dest="hatchSpacing", default=10.0,
                 help="Spacing between hatch lines")
-        self.OptionParser.add_option(
-                "--tolerance", action="store", type="float",
+        self.arg_parser.add_argument(
+                "--tolerance", action="store", type=float,
                 dest="tolerance", default=3.0,
                 help="Allowed deviation from original paths")
-        self.OptionParser.add_option(
+        self.arg_parser.add_argument(
                 "--units",
-                 action="store",  type="int",
+                 action="store",  type=int,
                  dest="units", default=1,
                  help="Units to use for hatches. 1: line width. 2: px. 3: mm. 4: inch")
 
-        self.OptionParser.add_option("--tab",  # NOTE: value is not used.
-                                     action="store", type="string", dest="_tab", default="splash",
+        self.arg_parser.add_argument("--tab",  # NOTE: value is not used.
+                                     action="store", type=str, dest="_tab", default="splash",
                                      help="The active tab when Apply was pressed")
                                      
 

--- a/inkscape_driver/eggbot_presethatch.py
+++ b/inkscape_driver/eggbot_presethatch.py
@@ -26,7 +26,7 @@ inkex = from_dependency_import('ink_extensions.inkex')
 class PresetHatch(inkex.Effect):
     def __init__(self):
         inkex.Effect.__init__(self)
-        self.OptionParser.add_option("--title")
+        self.arg_parser.add_argument("--title")
         self.svgDefRead = None
         self.svg = None
 

--- a/inkscape_driver/eggbot_stretch.py
+++ b/inkscape_driver/eggbot_stretch.py
@@ -146,12 +146,12 @@ class Map(inkex.Effect):
 
         inkex.Effect.__init__(self)
 
-        self.OptionParser.add_option('--smoothness', dest='smoothness',
-                                     type='float', default=float(0.2), action='store',
+        self.arg_parser.add_argument('--smoothness', dest='smoothness',
+                                     type=float, default=float(0.2), action='store',
                                      help='Curve smoothing (less for more)')
 
-        self.OptionParser.add_option('--maxDy', dest='maxDy',
-                                     type='float', default=float(5.0), action='store',
+        self.arg_parser.add_argument('--maxDy', dest='maxDy',
+                                     type=float, default=float(5.0), action='store',
                                      help='Vertical smoothing (less for more)')
 
         self.cx = float(N_PAGE_WIDTH) / 2.0


### PR DESCRIPTION
Extensions in inkscape_deprecated are unchanged

Extensions in inkscape_contributed were updated to be compatible with argparse, but were not tested.

Extensions in inkscape_driver were updated to be compatible with argparse, and tested briefly as inkscape extensions. Some additional changes were made to the build process and automated tests to account for these extensions.